### PR TITLE
Refactor `onData` callback being called by `useEffect`

### DIFF
--- a/src/use-infinite-subscription.ts
+++ b/src/use-infinite-subscription.ts
@@ -199,12 +199,18 @@ export function useInfiniteSubscription<
     refetchOnMount: true,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    onSuccess: options.onData,
     onError: (error: TError) => {
       clearErrors();
       options.onError && options.onError(error);
     },
   });
+
+  useEffect(() => {
+    if (queryResult.isSuccess) {
+      options.onData?.(queryResult.data);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryResult.data]);
 
   useEffect(() => {
     return function cleanup() {

--- a/src/use-subscription.ts
+++ b/src/use-subscription.ts
@@ -135,12 +135,18 @@ export function useSubscription<
     refetchOnMount: true,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    onSuccess: options.onData,
     onError: (error: TError) => {
       clearErrors();
       options.onError && options.onError(error);
     },
   });
+
+  useEffect(() => {
+    if (queryResult.isSuccess) {
+      options.onData?.(queryResult.data);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryResult.data]);
 
   useEffect(() => {
     return function cleanup() {


### PR DESCRIPTION
The `onSuccess` option has breaking changes in v4 and behaves differently

resolves #67