### PR TITLE
Refactor cancelation using `AbortController` and add unit tests

### DIFF
--- a/src/use-observable-query-fn.ts
+++ b/src/use-observable-query-fn.ts
@@ -70,6 +70,7 @@ export function useObservableQueryFn<
     if (signal) {
       signal.addEventListener('abort', cancel);
     } else {
+      /* istanbul ignore next */
       result.cancel = cancel;
     }
 


### PR DESCRIPTION
resolves #73, resolves #72 

[Query Cancellation Docs](https://tanstack.com/query/v4/docs/guides/query-cancellation)